### PR TITLE
Compensate IFFT window / zero-padding loss in TD

### DIFF
--- a/main.c
+++ b/main.c
@@ -154,41 +154,51 @@ static void transform_domain(void)
     // and calculate ifft for time domain
     float* tmp = (float*)spi_buffer;
 
+    // correct IFFT window and zero-padding loss
+    // assuming a 2*POINT_COUNT window
+    float wincorr = 1.0f;
+    float beta = 0.0;
+    switch (domain_mode & TD_WINDOW) {
+        case TD_WINDOW_MINIMUM:
+            beta = 0.0; // this is rectangular
+            wincorr = (float)FFT_SIZE / (float)(2*POINT_COUNT);
+            break;
+        case TD_WINDOW_NORMAL:
+            beta = 6.0;
+            wincorr = (float)FFT_SIZE / (float)(2*POINT_COUNT) * 2.01f;
+            break;
+        case TD_WINDOW_MAXIMUM:
+            beta = 13;
+            wincorr = (float)FFT_SIZE / (float)(2*POINT_COUNT) * 2.92f;
+            break;
+    }
+
     uint8_t window_size = POINT_COUNT, offset = 0;
     uint8_t is_lowpass = FALSE;
     switch (domain_mode & TD_FUNC) {
         case TD_FUNC_BANDPASS:
             offset = 0;
             window_size = POINT_COUNT;
+            // window size is half the size as assumed above => twice the IFFT loss
+            wincorr *= 2.0f;
             break;
-        case TD_FUNC_LOWPASS_IMPULSE:
         case TD_FUNC_LOWPASS_STEP:
+            // no IFFT losses need to be considered to calculate the step response
+            wincorr = 1.0f;
+            // fall-through
+        case TD_FUNC_LOWPASS_IMPULSE:
             is_lowpass = TRUE;
             offset = POINT_COUNT;
             window_size = POINT_COUNT * 2;
             break;
     }
 
-    float beta = 0.0;
-    switch (domain_mode & TD_WINDOW) {
-        case TD_WINDOW_MINIMUM:
-            beta = 0.0; // this is rectangular
-            break;
-        case TD_WINDOW_NORMAL:
-            beta = 6.0;
-            break;
-        case TD_WINDOW_MAXIMUM:
-            beta = 13;
-            break;
-    }
-
-
     for (int ch = 0; ch < 2; ch++) {
         memcpy(tmp, measured[ch], sizeof(measured[0]));
         for (int i = 0; i < POINT_COUNT; i++) {
             float w = kaiser_window(i+offset, window_size, beta);
-            tmp[i*2+0] *= w;
-            tmp[i*2+1] *= w;
+            tmp[i*2+0] *= w * wincorr;
+            tmp[i*2+1] *= w * wincorr;
         }
 #if POINT_COUNT >= FFT_SIZE
 #error CHECK ME

--- a/main.c
+++ b/main.c
@@ -161,14 +161,17 @@ static void transform_domain(void)
     switch (domain_mode & TD_WINDOW) {
         case TD_WINDOW_MINIMUM:
             beta = 0.0; // this is rectangular
+            // loss by zero-padding 202 to 256 points
             wincorr = (float)FFT_SIZE / (float)(2*POINT_COUNT);
             break;
         case TD_WINDOW_NORMAL:
             beta = 6.0;
+            // additional window loss: 1/mean(kaiser(202,6)) = 2.01
             wincorr = (float)FFT_SIZE / (float)(2*POINT_COUNT) * 2.01f;
             break;
         case TD_WINDOW_MAXIMUM:
             beta = 13;
+            // additional window loss: 1/mean(kaiser(202,13)) = 2.92
             wincorr = (float)FFT_SIZE / (float)(2*POINT_COUNT) * 2.92f;
             break;
     }


### PR DESCRIPTION
This change allows the firmware to compensate for signal processing losses in time-domain impulse response mode caused by zero-padding and windowing prior to the IFFT. I.e., a DUT with |S21| of 0 dB will then also show up as peak of 0 dB in time-domain mode, making the result comparable to other VNAs. Please see https://groups.io/g/nanovna-users/topic/should_the_builtin_tdr_mode/77043091 for exemplary measurements and discussion. 

The change increases the code (binary) size by 200 bytes.

Please feel to use this pull-request if you think this change could be part of your firmware.

PS: Thank you for your great work on the NanoVNA-H firmware!