### PR TITLE
Update lc_matching.c

### DIFF
--- a/lc_matching.c
+++ b/lc_matching.c
@@ -425,7 +425,7 @@ static void analysis_lcseries(void) {
   s21_measure->l = reff / ((2 * VNA_PI) * bw);
   s21_measure->c = bw / ((2 * VNA_PI) * fpeak * fpeak * reff);
   // q = 2*pi * Fp * Ls / R
-  s21_measure->q = (2 * VNA_PI) * fpeak * s21_measure->l / s21_measure->r;
+  s21_measure->q = (2 * VNA_PI) * fpeak * s21_measure->l / reff;
 
 //  s21_measure->f1 = f1;
 //  s21_measure->f2 = f2;


### PR DESCRIPTION
The formula for Q calculation is wrong. As stated in page 9 of https://www.mikrocontroller.net/attachment/473317/Crystal_Motional_Parameters.pdf (which this code is based from), **the fraction's denominator should be Reff**, which is 2* Zo+Rm.  However, the code uses Rm instead of Reff, which leads to absurdingly high Q values.

I noticed that when I was measuring a quartz crystal and VNA told me that the Q factor was over 77000 when it should be around 6800.